### PR TITLE
Revamp profile README layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 ### 🤝 Connect With Me
 <p align="center">
   <a href="https://davidtaylor6130.github.io/" target="_blank">
-    <img src="https://raw.githubusercontent.com/iconic/open-iconic/master/svg/globe.svg" alt="Website" width="30"/>
+    <img src="https://img.shields.io/badge/Website-000000?style=flat&logo=About.me&logoColor=white" alt="Website"/>
   </a>
   <a href="https://twitter.com/DavidTaylor6130" target="_blank">
-    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg" alt="Twitter" width="30"/>
+    <img src="https://img.shields.io/badge/Twitter-1DA1F2?style=flat&logo=twitter&logoColor=white" alt="Twitter"/>
   </a>
   <a href="https://www.linkedin.com/in/davidtaylor6130/" target="_blank">
-    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/linkedin.svg" alt="LinkedIn" width="30"/>
+    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=flat&logo=linkedin&logoColor=white" alt="LinkedIn"/>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 
 <h1 align="center">David Taylor</h1>
 <p align="center">
-  <em>Maker at heart • C++ Craftsman • Unity Asset Creator • Archer</em>
+  <em>Maker at heart • Passionate programmer • Unity asset creator</em>
+</p>
+<p align="center">
+  <em>Coding is my passion and what I truly enjoy.</em>
 </p>
 
 <p align="center">
@@ -36,52 +39,50 @@
 ---
 
 ### ✨ About Me
+- Coding is my passion—I love building things both at work and in my spare time.
 - **3+ years** of industrial experience, primarily in **C++**.
 - Skilled in **C#, JavaScript, Python, React,** and **Tailwind**.
 - Fascinated by **AI**, **web development**, and building in **Unity**.
-- Outside the code editor: gamer, **archery** enthusiast, cyclist, 3D-printing hobbyist, and nature walker.
+- Outside the editor: I enjoy gaming, archery, cycling, 3D printing, and nature walks.
 
 ### 🚧 Currently Building
-- [ ] **Release my first game to Steam**
-- [ ] **Finish all in progress projects** (7/20)
-- [ ] **Match or beat my 2024 total miles and walking streak (636 miles and 1 Jan – 8 Sep)**
+- ☐ **Release my first game to Steam**
+- ☐ **Finish all in progress projects** (7/20)
+- ☐ **Match or beat my 2024 total miles and walking streak (636 miles and 1 Jan – 8 Sep)**
 
 <details>
   <summary><strong>Project Completion Tracker</strong></summary>
 
-  - [x] OnlineFfmpegRunner.pages.dev (A website to run FFmpeg commands without installing it)
-  - [x] TheVideoConverterHub.pages.dev (v2 of TheVideoConverterHub.com, a one-stop shop for free and private video conversions)
-  - [x] TheAudioConverterHub.pages.dev (One stop shop for free and private audio conversions)
-  - [x] ThePhotoConverterHub.pages.dev (One stop shop for free and private photo conversions)
-  - [x] www.davidtaylor6130.co.uk (brand new personal website)
-  - [x] Stanley Fatmax Battery Caddy (A CAD project to store Stanley Fatmax batteries together)
-  - [x] Smart Meter Monitor shelf (A CAD project to mount my house's Smart Meter monitor on the wall, not the floor)
-  - [ ] Doodle Defense (a 2D card-based game of building a town and defending from waves of monsters)
-  - [ ] Interplanetary Delivery (Shoot rockets into space delivering packages while balancing speed and fuel)
-  - [ ] Pro Reset Game (A reset system that works with all other Unity scripts by accessing and altering Unity serialization)
-  - [ ] Free Level Load (Simple no-code level loading script)
-  - [ ] Free Simple Shooting (Simple shooting script for raycast, transform, and physics based)
-  - [ ] Free Cinemachine Camera Controller (Simplified controller for Cinemachine camera transitions and a lightweight version not requiring Cinemachine install)
-  - [ ] Free Simple Collision Detection (Simple script to handle all collisions)
-  - [ ] Free Tweening (A set of tweening scripts for quick and easy animations)
-  - [ ] TMC Core V3 (A custom editor system for Unity components that increases the look and usability of code)
-  - [ ] Pro NavMesh Controllable Entity (An upgraded and performant NavMesh-type component)
-  - [ ] Pro Build System (Building system for games made in Unity)
-  - [ ] Card System (A card deck system for Unity)
-  - [ ] Free Editor Extension (Multiple add-ons to the Unity editor)
+  - ✅ OnlineFfmpegRunner.pages.dev (A website to run FFmpeg commands without installing it)
+  - ✅ TheVideoConverterHub.pages.dev (v2 of TheVideoConverterHub.com, a one-stop shop for free and private video conversions)
+  - ✅ TheAudioConverterHub.pages.dev (One stop shop for free and private audio conversions)
+  - ✅ ThePhotoConverterHub.pages.dev (One stop shop for free and private photo conversions)
+  - ✅ www.davidtaylor6130.co.uk (brand new personal website)
+  - ✅ Stanley Fatmax Battery Caddy (A CAD project to store Stanley Fatmax batteries together)
+  - ✅ Smart Meter Monitor shelf (A CAD project to mount my house's Smart Meter monitor on the wall, not the floor)
+  - ☐ Doodle Defense (a 2D card-based game of building a town and defending from waves of monsters)
+  - ☐ Interplanetary Delivery (Shoot rockets into space delivering packages while balancing speed and fuel)
+  - ☐ Pro Reset Game (A reset system that works with all other Unity scripts by accessing and altering Unity serialization)
+  - ☐ Free Level Load (Simple no-code level loading script)
+  - ☐ Free Simple Shooting (Simple shooting script for raycast, transform, and physics based)
+  - ☐ Free Cinemachine Camera Controller (Simplified controller for Cinemachine camera transitions and a lightweight version not requiring Cinemachine install)
+  - ☐ Free Simple Collision Detection (Simple script to handle all collisions)
+  - ☐ Free Tweening (A set of tweening scripts for quick and easy animations)
+  - ☐ TMC Core V3 (A custom editor system for Unity components that increases the look and usability of code)
+  - ☐ Pro NavMesh Controllable Entity (An upgraded and performant NavMesh-type component)
+  - ☐ Pro Build System (Building system for games made in Unity)
+  - ☐ Card System (A card deck system for Unity)
+  - ☐ Free Editor Extension (Multiple add-ons to the Unity editor)
 </details>
 
 <details>
   <summary><strong>Previous New Year Goals</strong></summary>
 
   - 2024 Goals
-  - [x] **Buy my first home**
-  - [x] **Promoted from Junior Software Developer to Software Developer**
-  - [ ] **Release more code assets and speak about them**
+  - ✅ **Buy my first home**
+  - ✅ **Promoted from Junior Software Developer to Software Developer**
+  - ☐ **Release more code assets and speak about them**
 </details>
-
-### 🏹 Fun Fact
-- **Archery nerd:** I’ve mastered shooting three arrows into the bullseye from 20m.
 
 ---
 
@@ -208,9 +209,9 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 ---
 
 <p align="center">
-  <i>Thanks for stopping by! Feel free to reach out or explore my repos. Happy coding, and may your arrows always hit the target!</i>
+  <i>Thanks for stopping by! Feel free to reach out or explore my repos. Happy coding and keep building!</i>
 </p>
 
 <p align="center">
-  <em>Last Updated: 23/03/25</em>
+  <em>Last Updated: 06/09/25</em>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,234 +1,207 @@
-<!-- 
-  (Optional) If you have a banner image, uncomment the following and place your custom banner link
+<!--
+  Optional banner image:
   <p align="center">
     <img src="https://github.com/davidtaylor6130/davidtaylor6130/blob/main/banner.png" alt="David Taylor Banner"/>
   </p>
 -->
 
-<h1 align="center">Hey there, I'm David Taylor 
-  <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="28" />
-</h1>
-
+<h1 align="center">David Taylor</h1>
 <p align="center">
-  <b>C++ Programmer | AI & Web Dev Enthusiast | Unity Asset Creator | Archer</b>
+  <em>Maker at heart • C++ Craftsman • Unity Asset Creator • Archer</em>
 </p>
 
 <p align="center">
   <a href="https://github.com/davidtaylor6130?tab=followers">
-    <img src="https://img.shields.io/github/followers/davidtaylor6130?label=Followers&style=social" alt="GitHub Badge">
+    <img src="https://img.shields.io/github/followers/davidtaylor6130?label=Followers&style=social" alt="GitHub Badge"/>
   </a>
   <a href="https://twitter.com/DavidTaylor6130">
-    <img src="https://img.shields.io/twitter/follow/DavidTaylor6130?style=social" alt="Twitter Badge">
+    <img src="https://img.shields.io/twitter/follow/DavidTaylor6130?style=social" alt="Twitter Badge"/>
   </a>
   <a href="https://www.linkedin.com/in/davidtaylor6130/">
-    <img src="https://img.shields.io/badge/-LinkedIn-blue?style=flat&logo=Linkedin" alt="LinkedIn Badge">
+    <img src="https://img.shields.io/badge/-LinkedIn-blue?style=flat&logo=Linkedin" alt="LinkedIn Badge"/>
   </a>
   <a href="https://davidtaylor6130.github.io/">
-    <img src="https://img.shields.io/badge/-Portfolio-black?style=flat&logo=github" alt="Portfolio Badge">
+    <img src="https://img.shields.io/badge/-Portfolio-black?style=flat&logo=github" alt="Portfolio Badge"/>
   </a>
+</p>
+
+<p align="center">
+  <a href="#-about-me">About</a> •
+  <a href="#-currently-building">Goals</a> •
+  <a href="#-tech-toolbox">Tech</a> •
+  <a href="#-project-gallery">Projects</a> •
+  <a href="#-connect-with-me">Connect</a>
 </p>
 
 ---
 
-## 🚀 About Me
-
+### ✨ About Me
 - **3+ years** of industrial experience, primarily in **C++**.
-- Also skilled in **C#, JavaScript, Python, React,** and **Tailwind**.
-- Interested in **AI**, **Web Development**, and building on **Unity**.
-- Outside coding: I’m a gamer, **archery** enthusiast, cyclist, 3D printing hobbyist, and nature walker.
+- Skilled in **C#, JavaScript, Python, React,** and **Tailwind**.
+- Fascinated by **AI**, **web development**, and building in **Unity**.
+- Outside the code editor: gamer, **archery** enthusiast, cyclist, 3D-printing hobbyist, and nature walker.
 
-### 🎯 Current Goals
-
-- ❔ **Release my first game to steam**
-- ❔ **Finish all in progress projects** (7/20)
-- ❔ **Match or beat my 2024 total miles and walking streak (636 miles and 1st Jan -> 8th Sep)** 
+### 🚧 Currently Building
+- [ ] **Release my first game to Steam**
+- [ ] **Finish all in progress projects** (7/20)
+- [ ] **Match or beat my 2024 total miles and walking streak (636 miles and 1 Jan – 8 Sep)**
 
 <details>
+  <summary><strong>Project Completion Tracker</strong></summary>
 
-  <summary><strong>Progress on Finishing All My Projects</strong></summary>
-  
-  - ✅ OnlineFfmpegRunner.pages.dev  (A website to run ffmpeg commands on without needing to install it)
-  - ✅ TheVideoConverterHub.pages.dev (v2 of TheVideoConverterHub.com, a one stop shop for free and private video convertions)  
-  - ✅ TheAudioConverterHub.pages.dev  (One stop shop for free and private audio convertions)
-  - ✅ ThePhotoConverterHub.pages.dev  (One stop shop for free and private photo convertions)
-  - ✅ www.davidtaylor6130.co.uk  (brand new personal website)
-  - ✅ Standly Fatmax Battery Caddy (A Cad project to store Standly fatmax batterys together)
-  - ✅ Smart Meter Monitor shelf (A Cad Project to make a shelf that holds my houses Smart Meter Monitor on the wall and not on the floor)
-  - Doodle Defense (a 2d card based game of building a town and defending from waves of monitors)
-  - interplanitory Delivery (A game where you shoot rockets into space delivering packages balancing speed and fuel usage)
-  - Pro Reset Game (A reset system that works with all other unity script by acsessing and altering unity serlzation)
-  - Free Level Load (Simple non code level loading script)
-  - Free Simple Shooting (Simple shooting script for raycase, tranform, physics based)
-  - Free Cinemachine Camera controller (A simplified controller to the cinimachine camera transitions, and a lightweight version not requiring cinemachine install)
-  - Free Simple Collision Detection (Simple script to handle all collisions)
-  - Free Tweening (A set of tweening scripts for quick and easy animations)
-  - TMC Core V3 (A custom editor system for unity components which increase the looks and usability of codes)
-  - Pro Navmesh Controllable Entity (An upgrade and performant nav mesh type component)
-  - Pro Build System. (Building system for games made in unity)
-  - Card System (A card deck system for unity)
-  - Free Editior Extention (Multiple add on's to the unity editor)
+  - [x] OnlineFfmpegRunner.pages.dev (A website to run FFmpeg commands without installing it)
+  - [x] TheVideoConverterHub.pages.dev (v2 of TheVideoConverterHub.com, a one-stop shop for free and private video conversions)
+  - [x] TheAudioConverterHub.pages.dev (One stop shop for free and private audio conversions)
+  - [x] ThePhotoConverterHub.pages.dev (One stop shop for free and private photo conversions)
+  - [x] www.davidtaylor6130.co.uk (brand new personal website)
+  - [x] Stanley Fatmax Battery Caddy (A CAD project to store Stanley Fatmax batteries together)
+  - [x] Smart Meter Monitor shelf (A CAD project to mount my house's Smart Meter monitor on the wall, not the floor)
+  - [ ] Doodle Defense (a 2D card-based game of building a town and defending from waves of monsters)
+  - [ ] Interplanetary Delivery (Shoot rockets into space delivering packages while balancing speed and fuel)
+  - [ ] Pro Reset Game (A reset system that works with all other Unity scripts by accessing and altering Unity serialization)
+  - [ ] Free Level Load (Simple no-code level loading script)
+  - [ ] Free Simple Shooting (Simple shooting script for raycast, transform, and physics based)
+  - [ ] Free Cinemachine Camera Controller (Simplified controller for Cinemachine camera transitions and a lightweight version not requiring Cinemachine install)
+  - [ ] Free Simple Collision Detection (Simple script to handle all collisions)
+  - [ ] Free Tweening (A set of tweening scripts for quick and easy animations)
+  - [ ] TMC Core V3 (A custom editor system for Unity components that increases the look and usability of code)
+  - [ ] Pro NavMesh Controllable Entity (An upgraded and performant NavMesh-type component)
+  - [ ] Pro Build System (Building system for games made in Unity)
+  - [ ] Card System (A card deck system for Unity)
+  - [ ] Free Editor Extension (Multiple add-ons to the Unity editor)
 </details>
 
 <details>
-  <summary><strong>Previous NewYearGoals</strong></summary>
+  <summary><strong>Previous New Year Goals</strong></summary>
+
   - 2024 Goals
-  - ✅ **Buy my first home**  
-  - ✅ **Promoted from Junior Software Developer to Software Developer**  
-  - ❌ **Release more code assets and speak about them**
+  - [x] **Buy my first home**
+  - [x] **Promoted from Junior Software Developer to Software Developer**
+  - [ ] **Release more code assets and speak about them**
 </details>
 
 ### 🏹 Fun Fact
-
-- **Archery Nerd**: I’ve mastered shooting three arrows into the bullseye from 20m.
+- **Archery nerd:** I’ve mastered shooting three arrows into the bullseye from 20m.
 
 ---
 
-## 🛠 Tech & Tools
-
-<p align="left">
-  <!-- C++ -->
+### 🧰 Tech Toolbox
+<p align="center">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="C++" width="40" title="C++"/>
-  <!-- C# -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg" alt="C#" width="40" title="C#"/>
-  <!-- Python -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="Python" width="40" title="Python"/>
-  <!-- JavaScript -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" title="JavaScript"/>
-  <!-- React -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg" alt="React" width="40" title="React"/>
-  <!-- HTML5 -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg" alt="HTML5" width="40" title="HTML5"/>
-  <!-- CSS3 -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg" alt="CSS3" width="40" title="CSS3"/>
-  <!-- TensorFlow -->
   <img src="https://www.vectorlogo.zone/logos/tensorflow/tensorflow-icon.svg" alt="TensorFlow" width="40" title="TensorFlow"/>
-  <!-- VSCode -->
   <img src="https://code.visualstudio.com/assets/images/code-stable.png" alt="VS Code" width="40" title="Visual Studio Code"/>
-  <!-- Visual Studio Mac -->
   <img src="https://visualstudio.microsoft.com/wp-content/uploads/2019/05/VSMac2019_32px.svg" alt="Visual Studio for Mac" width="40" title="Visual Studio for Mac"/>
-  <!-- Visual Studio 2019 -->
   <img src="https://visualstudio.microsoft.com/wp-content/uploads/2019/06/BrandVisualStudioWin2019-3.svg" alt="Visual Studio 2019" width="40" title="Visual Studio 2019"/>
-  <!-- Unity -->
   <img src="https://www.vectorlogo.zone/logos/unity3d/unity3d-icon.svg" alt="Unity" width="40" title="Unity"/>
-  <!-- Unreal Engine 4 -->
   <img src="https://raw.githubusercontent.com/kenangundogan/fontisto/036b7eca71aab1bef8e6a0518f7329f13ed62f6b/icons/svg/brand/unreal-engine.svg" alt="Unreal Engine 4" width="40" title="Unreal Engine 4"/>
-  <!-- Git -->
   <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="Git" width="40" title="Git"/>
-  <!-- GitHub Desktop -->
   <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Desktop" width="40" title="GitHub Desktop"/>
-  <!-- Linux -->
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="Linux" width="40" title="Linux"/>
 </p>
 
 ---
 
-## 📈 GitHub Stats
-
+### 📈 GitHub Stats
 <p align="center">
   <picture>
-    <!-- Light Mode -->
-    <source 
-      srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=default&hide_border=true"
-      media="(prefers-color-scheme: light)"
-    />
-    <!-- Dark Mode -->
-    <img 
-      src="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=dracula&hide_border=true"
-      alt="David's Top Languages"
-      width="335"
-    />
+    <source srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=default&hide_border=true" media="(prefers-color-scheme: light)"/>
+    <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=dracula&hide_border=true" alt="David's Top Languages" width="335"/>
   </picture>
 </p>
 
 ---
 
-## ⚡ Projects & Highlights
-
-Below is a **curated** selection of my work. [Explore all repos here.](https://github.com/davidtaylor6130?tab=repositories)
+### 🚀 Project Gallery
+Below is a **curated** selection of my work. [Explore all repos →](https://github.com/davidtaylor6130?tab=repositories)
 
 <details>
   <summary><strong>Featured Projects</strong></summary>
 
-  - **FYP Self Driving Car**  
-    - **Tech:** C++, UE4, TensorFlow, Python  
-    - **Description:** Self-driving car on off-road terrains.  
+  - **FYP Self Driving Car**
+    - **Tech:** C++, UE4, TensorFlow, Python
+    - **Description:** Self-driving car on off-road terrains.
     - **Link:** [GitHub](https://github.com/davidtaylor6130/Final-Year-Project)
 
-  - **Going Quackers Engine**  
-    - **Tech:** C++, DirectX 11  
-    - **Description:** A custom 3D engine enabling swappable graphics APIs.  
+  - **Going Quackers Engine**
+    - **Tech:** C++, DirectX 11
+    - **Description:** A custom 3D engine enabling swappable graphics APIs.
     - **Link:** [GitHub](https://github.com/JennyBeanTheSkelepun/GGD-GoingQuackersFramework)
 
-  - **What Is Lurking In The Dark V2**  
-    - **Tech:** C#, Unity  
-    - **Description:** My long-term passion project (horror game).  
+  - **What Is Lurking In The Dark V2**
+    - **Tech:** C#, Unity
+    - **Description:** My long-term passion project (horror game).
     - **Link:** [GitHub](https://github.com/davidtaylor6130/PrivateRepSplashPage)
 </details>
 
 <details>
   <summary><strong>Unity Asset Store Releases</strong></summary>
 
-  - **Taylor Made Code Core**  
-    - **Description:** Backend for TMC scripts w/ custom UI system.  
+  - **Taylor Made Code Core**
+    - **Description:** Backend for TMC scripts w/ custom UI system.
     - **Link:** [Unity Asset Store](https://assetstore.unity.com/packages/tools/utilities/taylor-made-code-core-210510)
 
-  - **Free Sound Manager**  
-    - **Description:** Audio Source enhancements (random playback, fade, etc.).  
+  - **Free Sound Manager**
+    - **Description:** Audio Source enhancements (random playback, fade, etc.).
     - **Link:** [Unity Asset Store](https://assetstore.unity.com/packages/tools/audio/free-sound-manager-216294)
 
-  - **No Code Patrolling AI**  
-    - **Description:** Quick AI pathing setup for cars, animals, NPCs.  
+  - **No Code Patrolling AI**
+    - **Description:** Quick AI pathing setup for cars, animals, NPCs.
     - **Link:** [Unity Asset Store](https://assetstore.unity.com/packages/tools/behavior-ai/normal-ai-patrol-208801)
 
-  - **8-in-1 Cursor Movement**  
-    - **Description:** Multiple cursor-based movement styles for 2D/3D.  
+  - **8-in-1 Cursor Movement**
+    - **Description:** Multiple cursor-based movement styles for 2D/3D.
     - **Link:** [Unity Asset Store](https://assetstore.unity.com/packages/tools/utilities/normal-cursor-movement-269157)
 </details>
 
 <details>
   <summary><strong>Web Projects</strong></summary>
 
-  - **TheVideoConverterHub.com**  
-    - **Description:** Online video conversion w/ FFmpeg. Currently building a React-based redesign.  
+  - **TheVideoConverterHub.com**
+    - **Description:** Online video conversion w/ FFmpeg. Currently building a React-based redesign.
     - **Link:** [Website](https://www.thevideoconverterhub.com/)
 
-  - **demo.taylormadecode.com**  
-    - **Description:** Demos for TMC products, featuring custom Unity WebGL + React integration.  
+  - **demo.taylormadecode.com**
+    - **Description:** Demos for TMC products, featuring custom Unity WebGL + React integration.
     - **Link:** [Website](https://demo.taylormadecode.com/)
 
-  - **docs.taylormadecode.com**  
-    - **Description:** Docs for all TMC products, powered by custom Doxygen pipeline.  
+  - **docs.taylormadecode.com**
+    - **Description:** Docs for all TMC products, powered by custom Doxygen pipeline.
     - **Link:** [Website](https://docs.taylormadecode.com/)
 
-  - **gardening4you.co.uk**  
-    - **Description:** Seasonal gardening site updates automatically.  
+  - **gardening4you.co.uk**
+    - **Description:** Seasonal gardening site updates automatically.
     - **Link:** [Website](https://www.gardening4you.co.uk/)
 </details>
 
 <details>
   <summary><strong>Games & Other Repositories</strong></summary>
 
-  - **Escape The Code** (C#, Unity) – [GitHub](https://github.com/davidtaylor6130/Search-For-A-Star)  
-  - **WhatsChat** (C#, Networking) – [GitHub](https://github.com/davidtaylor6130/multi-threaded-networking/tree/master/Server)  
-  - **Low Level Optimisations** (C++, Linux) – [GitHub](https://github.com/davidtaylor6130/Low-Level-Programming)  
-  - **Lurking In The Dark** (C#, Unity) – [GitHub](https://github.com/davidtaylor6130/Lurking-In-The-Dark)  
-  - **Implode Engine** (C++, DirectX 11) – [GitHub](https://github.com/davidtaylor6130/further-graphical-systems)  
+  - **Escape The Code** (C#, Unity) – [GitHub](https://github.com/davidtaylor6130/Search-For-A-Star)
+  - **WhatsChat** (C#, Networking) – [GitHub](https://github.com/davidtaylor6130/multi-threaded-networking/tree/master/Server)
+  - **Low Level Optimisations** (C++, Linux) – [GitHub](https://github.com/davidtaylor6130/Low-Level-Programming)
+  - **Lurking In The Dark** (C#, Unity) – [GitHub](https://github.com/davidtaylor6130/Lurking-In-The-Dark)
+  - **Implode Engine** (C++, DirectX 11) – [GitHub](https://github.com/davidtaylor6130/further-graphical-systems)
   - **Coconut Sniper** (C#, Unity, Mobile) – [Google Play](https://play.google.com/store/apps/details?id=com.TaylorMadeCode.CoconutSniper)
 </details>
 
 ---
 
-## 📫 Connect With Me
-
+### 🤝 Connect With Me
 <p align="center">
   <a href="https://davidtaylor6130.github.io/" target="_blank">
-    <img src="https://raw.githubusercontent.com/iconic/open-iconic/master/svg/globe.svg" alt="Website" width="30" />
+    <img src="https://raw.githubusercontent.com/iconic/open-iconic/master/svg/globe.svg" alt="Website" width="30"/>
   </a>
   <a href="https://twitter.com/DavidTaylor6130" target="_blank">
-    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg" alt="Twitter" width="30" />
+    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg" alt="Twitter" width="30"/>
   </a>
   <a href="https://www.linkedin.com/in/davidtaylor6130/" target="_blank">
-    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/linkedin.svg" alt="LinkedIn" width="30" />
+    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/linkedin.svg" alt="LinkedIn" width="30"/>
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- restructure README with quick navigation and maker-focused tagline
- reorganize goals into project tracker and highlight tech toolbox
- tidy project gallery and connection links

## Testing
- `markdownlint README.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb79297e0832b9bc47c1b13ce60be