### PR TITLE
Refresh profile README for 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ### 🚧 Currently Building
 - [ ] 🤖 **Local LLM runner & wrapper** — self-hosted AI tooling I can build on top of
 - [ ] ⚙️ **AI automation workflows** with **n8n**
-- [ ] 🏠 **Homelab build-out** — self-hosting the things I rely on
+- [x] 🏠 **Homelab build-out** — self-hosting the things I rely on
 - [x] 🎮 **Ship more free Unity assets** — *Free Simple Shoot* just released
 - [ ] 🚴 **Stay active** — keep the cycling & walking streak going
 
@@ -106,14 +106,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg" alt="React" width="40" title="React"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/tailwindcss/tailwindcss-original.svg" alt="Tailwind CSS" width="40" title="Tailwind CSS"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg" alt="Node.js" width="40" title="Node.js"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg" alt="HTML5" width="40" title="HTML5"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg" alt="CSS3" width="40" title="CSS3"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/unity/unity-original.svg" alt="Unity" width="40" title="Unity"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/unrealengine/unrealengine-original.svg" alt="Unreal Engine" width="40" title="Unreal Engine"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/tensorflow/tensorflow-original.svg" alt="TensorFlow" width="40" title="TensorFlow"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="Git" width="40" title="Git"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="Linux" width="40" title="Linux"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/vscode/vscode-original.svg" alt="VS Code" width="40" title="Visual Studio Code"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/visualstudio/visualstudio-original.svg" alt="Visual Studio" width="40" title="Visual Studio"/>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,33 +5,35 @@
   </p>
 -->
 
-<h1 align="center">David Taylor</h1>
+<h1 align="center">Hi, I'm David Taylor 👋</h1>
+
 <p align="center">
-  <em>Maker at heart • Passionate programmer • Unity asset creator</em>
-</p>
-<p align="center">
-  <em>Coding is my passion and what I truly enjoy.</em>
+  <a href="https://www.davidtaylor6130.co.uk/">
+    <img src="https://readme-typing-svg.demolab.com/?font=Fira+Code&weight=500&size=22&pause=900&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=Maker+at+heart%2C+passionate+programmer;Unity+asset+creator+%26+homelab+tinkerer;Now+building+local+LLM+tools+%26+AI+automation" alt="What I do"/>
+  </a>
 </p>
 
 <p align="center">
   <a href="https://github.com/davidtaylor6130?tab=followers">
-    <img src="https://img.shields.io/github/followers/davidtaylor6130?label=Followers&style=social" alt="GitHub Badge"/>
+    <img src="https://img.shields.io/github/followers/davidtaylor6130?label=Followers&style=social" alt="GitHub Followers"/>
   </a>
+  <img src="https://komarev.com/ghpvc/?username=davidtaylor6130&label=Profile%20views&color=58A6FF&style=flat" alt="Profile views"/>
   <a href="https://twitter.com/DavidTaylor6130">
-    <img src="https://img.shields.io/twitter/follow/DavidTaylor6130?style=social" alt="Twitter Badge"/>
+    <img src="https://img.shields.io/badge/-X-000000?style=flat&logo=x&logoColor=white" alt="X / Twitter"/>
   </a>
   <a href="https://www.linkedin.com/in/davidtaylor6130/">
-    <img src="https://img.shields.io/badge/-LinkedIn-blue?style=flat&logo=Linkedin" alt="LinkedIn Badge"/>
+    <img src="https://img.shields.io/badge/-LinkedIn-0A66C2?style=flat&logo=linkedin&logoColor=white" alt="LinkedIn"/>
   </a>
-  <a href="https://davidtaylor6130.github.io/">
-    <img src="https://img.shields.io/badge/-Portfolio-black?style=flat&logo=github" alt="Portfolio Badge"/>
+  <a href="https://www.davidtaylor6130.co.uk/">
+    <img src="https://img.shields.io/badge/-Portfolio-1F6FEB?style=flat&logo=googlechrome&logoColor=white" alt="Portfolio"/>
   </a>
 </p>
 
 <p align="center">
   <a href="#-about-me">About</a> •
-  <a href="#-currently-building">Goals</a> •
+  <a href="#-currently-building">Building</a> •
   <a href="#-tech-toolbox">Tech</a> •
+  <a href="#-github-stats">Stats</a> •
   <a href="#-project-gallery">Projects</a> •
   <a href="#-connect-with-me">Connect</a>
 </p>
@@ -39,19 +41,22 @@
 ---
 
 ### ✨ About Me
-- Coding is my passion—I love building things both at work and in my spare time.
-- **3+ years** of industrial experience, primarily in **C++**.
-- Skilled in **C#, JavaScript, Python, React,** and **Tailwind**.
-- Fascinated by **AI**, **web development**, and building in **Unity**.
-- Outside the editor: I enjoy gaming, archery, cycling, 3D printing, and nature walks.
+- Coding is my passion — I love building things at work **and** in my spare time.
+- **4+ years** of industrial experience, primarily in **C++**.
+- Comfortable across **C#, JavaScript, Python, React,** and **Tailwind**.
+- Lately I'm deep in **local LLMs**, **AI automation** with n8n, and building out my **homelab**.
+- Still a **Unity asset creator** at heart, shipping free tools for other devs.
+- Outside the editor: gaming, archery, cycling, 3D printing, and nature walks.
 
 ### 🚧 Currently Building
-- ☐ **Release my first game to Steam**
-- ☐ **Finish all in progress projects** (7/20)
-- ☐ **Match or beat my 2024 total miles and walking streak (636 miles and 1 Jan – 8 Sep)**
+- [ ] 🤖 **Local LLM runner & wrapper** — self-hosted AI tooling I can build on top of
+- [ ] ⚙️ **AI automation workflows** with **n8n**
+- [ ] 🏠 **Homelab build-out** — self-hosting the things I rely on
+- [x] 🎮 **Ship more free Unity assets** — *Free Simple Shoot* just released
+- [ ] 🚴 **Stay active** — keep the cycling & walking streak going
 
 <details>
-  <summary><strong>Project Completion Tracker</strong></summary>
+  <summary><strong>📦 Project Completion Tracker (8/20)</strong></summary>
 
   - ✅ OnlineFfmpegRunner.pages.dev (A website to run FFmpeg commands without installing it)
   - ✅ TheVideoConverterHub.pages.dev (v2 of TheVideoConverterHub.com, a one-stop shop for free and private video conversions)
@@ -60,11 +65,11 @@
   - ✅ www.davidtaylor6130.co.uk (brand new personal website)
   - ✅ Stanley Fatmax Battery Caddy (A CAD project to store Stanley Fatmax batteries together)
   - ✅ Smart Meter Monitor shelf (A CAD project to mount my house's Smart Meter monitor on the wall, not the floor)
+  - ✅ Free Simple Shoot (Simple shooting script for raycast, transform, and physics based)
   - ☐ Doodle Defense (a 2D card-based game of building a town and defending from waves of monsters)
   - ☐ Interplanetary Delivery (Shoot rockets into space delivering packages while balancing speed and fuel)
   - ☐ Pro Reset Game (A reset system that works with all other Unity scripts by accessing and altering Unity serialization)
   - ☐ Free Level Load (Simple no-code level loading script)
-  - ☐ Free Simple Shooting (Simple shooting script for raycast, transform, and physics based)
   - ☐ Free Cinemachine Camera Controller (Simplified controller for Cinemachine camera transitions and a lightweight version not requiring Cinemachine install)
   - ☐ Free Simple Collision Detection (Simple script to handle all collisions)
   - ☐ Free Tweening (A set of tweening scripts for quick and easy animations)
@@ -76,10 +81,15 @@
 </details>
 
 <details>
-  <summary><strong>Previous New Year Goals</strong></summary>
+  <summary><strong>🏆 Highlights & Past Goals</strong></summary>
 
-  - 2024 Goals
-  - ✅ **Buy my first home**
+  **2025**
+  - ✅ Shipped **Free Simple Shoot** (Unity asset)
+  - ✅ Pivoted into **AI / local-LLM tooling** & started a **homelab**
+  - ✅ Lost **40kg** 💪 (personal milestone)
+
+  **2024**
+  - ✅ **Bought my first home**
   - ✅ **Promoted from Junior Software Developer to Software Developer**
   - ☐ **Release more code assets and speak about them**
 </details>
@@ -87,42 +97,63 @@
 ---
 
 ### 🧰 Tech Toolbox
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="C++" width="40" title="C++"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg" alt="C#" width="40" title="C#"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="Python" width="40" title="Python"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" title="JavaScript"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg" alt="React" width="40" title="React"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/tailwindcss/tailwindcss-original.svg" alt="Tailwind CSS" width="40" title="Tailwind CSS"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg" alt="Node.js" width="40" title="Node.js"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg" alt="HTML5" width="40" title="HTML5"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg" alt="CSS3" width="40" title="CSS3"/>
-  <img src="https://www.vectorlogo.zone/logos/tensorflow/tensorflow-icon.svg" alt="TensorFlow" width="40" title="TensorFlow"/>
-  <img src="https://code.visualstudio.com/assets/images/code-stable.png" alt="VS Code" width="40" title="Visual Studio Code"/>
-  <img src="https://visualstudio.microsoft.com/wp-content/uploads/2019/05/VSMac2019_32px.svg" alt="Visual Studio for Mac" width="40" title="Visual Studio for Mac"/>
-  <img src="https://visualstudio.microsoft.com/wp-content/uploads/2019/06/BrandVisualStudioWin2019-3.svg" alt="Visual Studio 2019" width="40" title="Visual Studio 2019"/>
-  <img src="https://www.vectorlogo.zone/logos/unity3d/unity3d-icon.svg" alt="Unity" width="40" title="Unity"/>
-  <img src="https://raw.githubusercontent.com/kenangundogan/fontisto/036b7eca71aab1bef8e6a0518f7329f13ed62f6b/icons/svg/brand/unreal-engine.svg" alt="Unreal Engine 4" width="40" title="Unreal Engine 4"/>
-  <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="Git" width="40" title="Git"/>
-  <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Desktop" width="40" title="GitHub Desktop"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/unity/unity-original.svg" alt="Unity" width="40" title="Unity"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/unrealengine/unrealengine-original.svg" alt="Unreal Engine" width="40" title="Unreal Engine"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/tensorflow/tensorflow-original.svg" alt="TensorFlow" width="40" title="TensorFlow"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="Git" width="40" title="Git"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="Linux" width="40" title="Linux"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/vscode/vscode-original.svg" alt="VS Code" width="40" title="Visual Studio Code"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/visualstudio/visualstudio-original.svg" alt="Visual Studio" width="40" title="Visual Studio"/>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Local%20LLMs-Ollama-000000?style=flat-square&logo=ollama&logoColor=white" alt="Local LLMs / Ollama"/>
+  <img src="https://img.shields.io/badge/Automation-n8n-EA4B71?style=flat-square&logo=n8n&logoColor=white" alt="n8n"/>
+  <img src="https://img.shields.io/badge/Containers-Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker"/>
+  <img src="https://img.shields.io/badge/Homelab-self--hosted-1F6FEB?style=flat-square&logo=homeassistant&logoColor=white" alt="Homelab"/>
 </p>
 
 ---
 
 ### 📈 GitHub Stats
+
 <p align="center">
   <picture>
-    <source srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=default&hide_border=true" media="(prefers-color-scheme: light)"/>
-    <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&theme=dracula&hide_border=true" alt="David's Top Languages" width="335"/>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=davidtaylor6130&show_icons=true&hide_border=true&count_private=true&theme=tokyonight"/>
+    <img src="https://github-readme-stats.vercel.app/api?username=davidtaylor6130&show_icons=true&hide_border=true&count_private=true" alt="David's GitHub Stats" height="165"/>
+  </picture>
+  &nbsp;
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&hide_border=true&theme=tokyonight"/>
+    <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=davidtaylor6130&layout=compact&hide_border=true" alt="David's Top Languages" height="165"/>
+  </picture>
+</p>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com/?user=davidtaylor6130&hide_border=true&theme=tokyonight"/>
+    <img src="https://streak-stats.demolab.com/?user=davidtaylor6130&hide_border=true" alt="David's GitHub Streak"/>
   </picture>
 </p>
 
 ---
 
 ### 🚀 Project Gallery
-Below is a **curated** selection of my work. [Explore all repos →](https://github.com/davidtaylor6130?tab=repositories)
+A **curated** selection of my work. [Explore all repos →](https://github.com/davidtaylor6130?tab=repositories)
 
 <details>
-  <summary><strong>Featured Projects</strong></summary>
+  <summary><strong>⭐ Featured Projects</strong></summary>
 
   - **FYP Self Driving Car**
     - **Tech:** C++, UE4, TensorFlow, Python
@@ -141,7 +172,11 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 </details>
 
 <details>
-  <summary><strong>Unity Asset Store Releases</strong></summary>
+  <summary><strong>🎮 Unity Asset Store Releases</strong></summary>
+
+  - **Free Simple Shoot** *(newly released)*
+    - **Description:** Simple shooting for raycast, transform, and physics-based setups.
+    - **Link:** [Unity Asset Store](https://assetstore.unity.com/?q=Free%20Simple%20Shoot&orderBy=1)
 
   - **Taylor Made Code Core**
     - **Description:** Backend for TMC scripts w/ custom UI system.
@@ -161,7 +196,7 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 </details>
 
 <details>
-  <summary><strong>Web Projects</strong></summary>
+  <summary><strong>🌐 Web Projects</strong></summary>
 
   - **TheVideoConverterHub.com**
     - **Description:** Online video conversion w/ FFmpeg. Currently building a React-based redesign.
@@ -176,12 +211,12 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
     - **Link:** [Website](https://docs.taylormadecode.com/)
 
   - **gardening4you.co.uk**
-    - **Description:** Seasonal gardening site updates automatically.
+    - **Description:** Seasonal gardening site that updates automatically.
     - **Link:** [Website](https://www.gardening4you.co.uk/)
 </details>
 
 <details>
-  <summary><strong>Games & Other Repositories</strong></summary>
+  <summary><strong>🕹️ Games & Other Repositories</strong></summary>
 
   - **Escape The Code** (C#, Unity) – [GitHub](https://github.com/davidtaylor6130/Search-For-A-Star)
   - **WhatsChat** (C#, Networking) – [GitHub](https://github.com/davidtaylor6130/multi-threaded-networking/tree/master/Server)
@@ -195,14 +230,14 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 
 ### 🤝 Connect With Me
 <p align="center">
-  <a href="https://davidtaylor6130.github.io/" target="_blank">
-    <img src="https://img.shields.io/badge/Website-000000?style=flat&logo=About.me&logoColor=white" alt="Website"/>
+  <a href="https://www.davidtaylor6130.co.uk/" target="_blank">
+    <img src="https://img.shields.io/badge/Website-1F6FEB?style=flat&logo=googlechrome&logoColor=white" alt="Website"/>
   </a>
   <a href="https://twitter.com/DavidTaylor6130" target="_blank">
-    <img src="https://img.shields.io/badge/Twitter-1DA1F2?style=flat&logo=twitter&logoColor=white" alt="Twitter"/>
+    <img src="https://img.shields.io/badge/X-000000?style=flat&logo=x&logoColor=white" alt="X / Twitter"/>
   </a>
   <a href="https://www.linkedin.com/in/davidtaylor6130/" target="_blank">
-    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=flat&logo=linkedin&logoColor=white" alt="LinkedIn"/>
+    <img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat&logo=linkedin&logoColor=white" alt="LinkedIn"/>
   </a>
 </p>
 
@@ -213,5 +248,5 @@ Below is a **curated** selection of my work. [Explore all repos →](https://git
 </p>
 
 <p align="center">
-  <em>Last Updated: 06/09/25</em>
+  <em>Last updated: June 2026</em>
 </p>


### PR DESCRIPTION
Refreshes the profile README, which was last updated ~9 months ago.

## Content
- Reframe focus around **local LLM tooling, n8n AI automation, and homelab**
- Drop the parked Steam goal; tick the homelab build-out goal
- Mark **Free Simple Shoot** as released (tracker now 8/20) and add it to Unity Asset Store releases
- New "Highlights & Past Goals" archive (2025: asset release, AI pivot, 40kg milestone — over the 2024 archive)

## Visuals
- Animated typing header
- Stats block: overall stats + top languages + contribution streak, with light/dark variants
- Profile-views counter
- Trimmed tech toolbox to: C++, C#, Python, JavaScript, React, Tailwind, Node.js, Unity, Linux, Visual Studio — plus an AI/automation/homelab badge row (Ollama, n8n, Docker, Homelab)
- Twitter → X branding; Website/Portfolio now point to davidtaylor6130.co.uk
- Footer updated to June 2026