### PR TITLE
Widen typing SVG canvas to fix clipped text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://www.davidtaylor6130.co.uk/">
-    <img src="https://readme-typing-svg.demolab.com/?font=Fira+Code&weight=500&size=22&pause=900&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=Maker+at+heart%2C+passionate+programmer;Unity+asset+creator+%26+homelab+tinkerer;Currently+building+local+LLM+tools+%26+AI+automation" alt="What I do"/>
+    <img src="https://readme-typing-svg.demolab.com/?font=Fira+Code&weight=500&size=22&pause=900&color=58A6FF&center=true&vCenter=true&width=740&height=50&lines=Maker+at+heart%2C+passionate+programmer;Unity+asset+creator+%26+homelab+tinkerer;Currently+building+local+LLM+tools+%26+AI+automation" alt="What I do"/>
   </a>
 </p>
 


### PR DESCRIPTION
The animated header line was clipping ~3 chars on each side after "Now" became "Currently". Bumped width 620 -> 740 so the longest centered line fits.